### PR TITLE
WA-002-no-double-database

### DIFF
--- a/config/mongoseed/seed_db.sh
+++ b/config/mongoseed/seed_db.sh
@@ -2,4 +2,4 @@ sleep 2
 echo "=========> Inserting Workout Test Data"
 mongoimport --host mongodb --db "workouts-database" --collection workouts --file ./workout.json --jsonArray
 
-mongosh mongodb:27017/workoutDb ./create_indices.js
+mongosh mongodb:27017/workouts-database ./create_indices.js

--- a/server/server.js
+++ b/server/server.js
@@ -1,6 +1,5 @@
 import express from "express";
 import dotenv from "dotenv";
-// import { message } from "./message.js";
 
 dotenv.config();
 


### PR DESCRIPTION
Small fix, mongo seed script was creating a secondary database in the create_indices.js file